### PR TITLE
Add configuration file infrastructure for reboot method selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,12 @@ sbin/transactional-update
 man/transactional-update.8
 man/transactional-update.service.8
 man/transactional-update.timer.8
+man/transactional-update.conf.5
 man/transactional-update.8.html
 man/transactional-update.index.xml
 man/transactional-update.service.8.html
 man/transactional-update.timer.8.html
+man/transactional-update.conf.5.html
 man/transactional-update.index.html
 transactional-update-*.tar.*
 doc/transactional-update.txt

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@
 #
 AUTOMAKE_OPTIONS = 1.6 foreign check-news dist-bzip2
 #
-SUBDIRS = sbin man systemd logrotate doc
+SUBDIRS = sbin man systemd logrotate doc etc
 
 CLEANFILES = *~
 

--- a/configure.ac
+++ b/configure.ac
@@ -65,4 +65,5 @@ else
 fi
 
 AC_OUTPUT([Makefile sbin/Makefile man/Makefile systemd/Makefile \
-	logrotate/Makefile doc/Makefile sbin/transactional-update])
+	logrotate/Makefile doc/Makefile etc/Makefile \
+	sbin/transactional-update])

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2018 Ignaz Forster <iforster@suse.com>
+#
+
+sysconf_DATA = transactional-update.conf
+
+EXTRA_DIST = $(DATA)

--- a/etc/transactional-update.conf
+++ b/etc/transactional-update.conf
@@ -1,0 +1,6 @@
+# Configuration file for transactional-update
+# See transactional-update.conf(5) for details
+
+# Reboot method
+# Valid values: auto salt rebootmgr systemd
+#REBOOT_METHOD=auto

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -39,6 +39,10 @@ transactional-update.index.xml: make-man-index.py $(XMLS)
 transactional-update.8: transactional-update.8.xml
 	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude --nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<
 
+transactional-update.service.8: transactional-update.8
+
+transactional-update.timer.8: transactional-update.8
+
 transactional-update.8.html: transactional-update.8.xml custom-html.xsl
 	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) $(XSLTPROC_FLAGS_HTML) $<
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -10,12 +10,13 @@ EXTRA_DIST = $(MANS) $(XMLS) $(DATA) custom-html.xsl make-man-index.py \
 	xml_helper.py transactional-update.index.xml
 
 man_MANS = transactional-update.8 transactional-update.service.8 \
-	transactional-update.timer.8
+	transactional-update.timer.8 transactional-update.conf.5
 
 noinst_DATA = transactional-update.8.html transactional-update.service.8.html \
-	transactional-update.timer.8.html transactional-update.index.html
+	transactional-update.timer.8.html transactional-update.conf.5.html \
+	transactional-update.index.html
 
-XMLS = transactional-update.8.xml
+XMLS = transactional-update.8.xml transactional-update.conf.5.xml
 
 XSLTPROC_FLAGS_HTML = \
         --nonet \
@@ -53,6 +54,12 @@ transactional-update.timer.8.html: transactional-update.8.html
 	$(html_alias)
 
 transactional-update.index.html: transactional-update.index.xml custom-html.xsl
+	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) $(XSLTPROC_FLAGS_HTML) $<
+
+transactional-update.conf.5: transactional-update.conf.5.xml
+	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) --xinclude --nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<
+
+transactional-update.conf.5.html: transactional-update.conf.5.xml custom-html.xsl
 	$(XSLTPROC) -o $(srcdir)/$@ --path $(srcdir) $(XSLTPROC_FLAGS_HTML) $<
 
 endif

--- a/man/transactional-update.8.xml
+++ b/man/transactional-update.8.xml
@@ -335,7 +335,8 @@ for more informations.
 </refsect1>
 
 <refsect1 id='see_also'><title>SEE ALSO</title>
-<para><citerefentry project='systemd'><refentrytitle>systemd.timer</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
+<para><citerefentry><refentrytitle>transactional-update.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
+<citerefentry project='systemd'><refentrytitle>systemd.timer</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
 <citerefentry project='systemd'><refentrytitle>systemd.time</refentrytitle><manvolnum>7</manvolnum></citerefentry></para>
 </refsect1>
 </refentry>

--- a/man/transactional-update.conf.5.xml
+++ b/man/transactional-update.conf.5.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
+"http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
+
+<!--  \-*\- nroff \-*\- -->
+<!--  Copyright 2018 Ignaz Forster &lt;iforster@suse.com&gt; -->
+
+<!--  This file is part of transactional-update. -->
+
+<!--  This program is free software; you can redistribute it and/or -->
+<!--  modify it under the terms of the GNU General Public License -->
+<!--  as published by the Free Software Foundation; either version 2 -->
+<!--  of the License, or (at your option) any later version. -->
+
+<!--  This program is distributed in the hope that it will be useful, -->
+<!--  but WITHOUT ANY WARRANTY; without even the implied warranty of -->
+<!--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the -->
+<!--  GNU General Public License for more details. -->
+
+<!--  You should have received a copy of the GNU General Public License -->
+<!--  along with this program; if not, see <http://www.gnu.org/licenses/>. -->
+
+<refentry id="transactional-update.conf.5">
+  <refentryinfo>
+    <title>transactional-update.conf</title>
+    <productname>transactional-update</productname>
+
+    <authorgroup>
+      <author>
+        <contrib></contrib>
+        <firstname>Ignaz</firstname>
+        <surname>Forster</surname>
+        <email>iforster@suse.com</email>
+      </author>
+    </authorgroup>
+  </refentryinfo>
+
+  <refmeta>
+    <refentrytitle>transactional-update.conf</refentrytitle>
+    <manvolnum>5</manvolnum>
+  </refmeta>
+
+  <refnamediv>
+    <refname>transactional-update.conf</refname>
+    <refpurpose>transactional-update configuration file</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <para><filename>/etc/transactional-update.conf</filename></para>
+  </refsynopsisdiv>
+
+  <refsect1>
+    <title>Description</title>
+
+    <para>This configuration file controls and defines the behaviour of
+    <citerefentry>
+      <refentrytitle>transactional-update</refentrytitle>
+      <manvolnum>8</manvolnum>
+    </citerefentry>.</para>
+  </refsect1>
+
+  <refsect1>
+    <title>Options</title>
+
+    <para>The following options are available in the
+      <literal>transactional-update</literal> section:
+    </para>
+
+    <variablelist>
+      <varlistentry>
+        <term><varname>REBOOT_METHOD=&lt;auto|salt|rebootmgr|systemd&gt;</varname></term>
+        <listitem>
+	  <para>
+            Specify the reboot method to use. If the value is <literal>auto
+            </literal> rebootmgr will be used to reboot the system; if
+            rebootmgr is not installed or running systemd will be used as a
+            fallback. If the value is <literal>salt</literal>,
+            <literal>rebootmgr</literal> or <literal>systemd</literal> the
+            corresponding mechanism will be called for rebooting the system.
+            Default and fallback on unkown values is <literal>auto</literal>.
+        </para>
+	</listitem>
+      </varlistentry>
+
+    </variablelist>
+  </refsect1>
+
+  <refsect1 id='see_also'>
+    <title>See Also</title>
+    <para>
+      <citerefentry><refentrytitle>transactional-update</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+    </para>
+  </refsect1>
+
+</refentry>

--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -229,9 +229,6 @@ reboot_via_systemd() {
 }
 
 reboot_autodetect() {
-    if [ $USE_SALT_GRAINS -eq 1 ]; then
-	reboot_via_salt
-    fi
     if [ -x /usr/sbin/rebootmgrctl ]; then
 	reboot_via_rebootmgr
     fi
@@ -356,6 +353,7 @@ while [ 1 ]; do
 	salt)
 	    REBOOT_AFTERWARDS=1
 	    USE_SALT_GRAINS=1
+	    REBOOT_METHOD="salt"
 	    shift
 	    ;;
         -h|--help)

--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -36,6 +36,7 @@ ROLLBACK_SNAPSHOT=0
 REBOOT_AFTERWARDS=0
 RUN_SHELL=0
 USE_SALT_GRAINS=0
+CONFFILE="/etc/transactional-update.conf"
 LOGFILE="/var/log/transactional-update.log"
 STATE_FILE="/var/lib/misc/transactional-update.state"
 PACKAGE_UPDATES=0
@@ -46,6 +47,11 @@ KDUMP_SYSCONFIG="/etc/sysconfig/kdump"
 # Config files, which the user could have modified and which should
 # be copied to the snapshot.
 CONFIG_FILES_TO_COPY="/etc/default/grub"
+
+# load config
+if [ -r ${CONFFILE} ]; then
+    . ${CONFFILE}
+fi
 
 usage() {
     echo "Usage: transactional-update --help|--version"

--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -34,6 +34,7 @@ DO_MIGRATION=0
 DO_ROLLBACK=0
 ROLLBACK_SNAPSHOT=0
 REBOOT_AFTERWARDS=0
+REBOOT_METHOD="auto"
 RUN_SHELL=0
 USE_SALT_GRAINS=0
 CONFFILE="/etc/transactional-update.conf"
@@ -189,6 +190,53 @@ quit() {
     fi
     log_info "transactional-update finished"
     exit $1
+}
+
+reboot_via_salt() {
+    log_info "transactional-update finished - created salt grains"
+    if [ -f /etc/salt/grains ]; then
+	grep -q tx_update_reboot_needed /etc/salt/grains
+	if [ $? -ne 0 ]; then
+	    # Add variable to existing salt grains
+	    echo "tx_update_reboot_needed: true" >> /etc/salt/grains
+	else
+	    # modify variable in existing salt grains
+	    sed -i -e 's|tx_update_reboot_needed:.*|tx_update_reboot_needed: true|g' /etc/salt/grains
+	fi
+    else
+	echo "tx_update_reboot_needed: true" > /etc/salt/grains
+    fi
+    # Reset tx_update_failed if exist
+    sed -i -e 's|tx_update_failed:.*|tx_update_failed: false|g' /etc/salt/grains
+    exit 0
+}
+
+reboot_via_rebootmgr() {
+    /usr/sbin/rebootmgrctl is-active --quiet
+    if [ $? -eq 0 ]; then
+	# rebootmgrctl is running
+	/usr/sbin/rebootmgrctl reboot
+	log_info "transactional-update finished - informed rebootmgr"
+	exit 0
+    fi
+}
+
+reboot_via_systemd() {
+    log_info "transactional-update finished - rebooting machine"
+    sync
+    systemctl reboot |& tee -a ${LOGFILE}
+    exit 0
+}
+
+reboot_autodetect() {
+    if [ $USE_SALT_GRAINS -eq 1 ]; then
+	reboot_via_salt
+    fi
+    if [ -x /usr/sbin/rebootmgrctl ]; then
+	reboot_via_rebootmgr
+    fi
+    # If rebootmgr is inactive try systemd
+    reboot_via_systemd
 }
 
 add_unique_id() {
@@ -767,37 +815,27 @@ fi
 
 if [ ${EXITCODE} -eq 0 ]; then
     if [ $REBOOT_AFTERWARDS -eq 1 ]; then
-	if [ $USE_SALT_GRAINS -eq 1 ]; then
-	    log_info "transactional-update finished - created salt grains"
-	    if [ -f /etc/salt/grains ]; then
-		grep -q tx_update_reboot_needed /etc/salt/grains
-		if [ $? -ne 0 ]; then
-		    # Add variable to existing salt grains
-		    echo "tx_update_reboot_needed: true" >> /etc/salt/grains
-		else
-		    # modify variable in existing salt grains
-		    sed -i -e 's|tx_update_reboot_needed:.*|tx_update_reboot_needed: true|g' /etc/salt/grains
-		fi
-	    else
-		echo "tx_update_reboot_needed: true" > /etc/salt/grains
-	    fi
-	    # Reset tx_update_failed if exist
-	    sed -i -e 's|tx_update_failed:.*|tx_update_failed: false|g' /etc/salt/grains
-	    exit 0
-	else
-	    if [ -x /usr/sbin/rebootmgrctl ]; then
-		/usr/sbin/rebootmgrctl is-active --quiet
-		if [ $? -eq 0 ]; then
-		    # rebootmgrctl is running
-		    /usr/sbin/rebootmgrctl reboot
-		    log_info "transactional-update finished - informed rebootmgr"
-		    exit 0
-		fi
-	    fi
-	    log_info "transactional-update finished - rebooting machine"
-	    sync
-	    systemctl reboot |& tee -a ${LOGFILE}
-	fi
+	case "$REBOOT_METHOD" in
+	    auto)
+		reboot_autodetect
+		;;
+	    salt)
+		reboot_via_salt
+		;;
+	    rebootmgr)
+		reboot_via_rebootmgr
+		;;
+	    systemd)
+		reboot_via_systemd
+		;;
+	    *)
+	        log_info "Unsupported reboot method, falling back to 'auto'; please"
+	        log_info "check your configuration in ${CONFFILE}."
+	        reboot_autodetect
+	        ;;
+	esac
+	echo "The system couldn't be rebooted using method '{$REBOOT_METHOD}'. Please reboot the system"
+	echo "manually."
     elif [ $PACKAGE_UPDATES -gt 1 ]; then
 	echo "Please reboot your machine to activate the changes and avoid data loss"
     fi


### PR DESCRIPTION
With the upcoming introduction of "kured" as another reboot method there needs to be some way to choose which method is supposed to be used. This is done by introducing the configuration file _/etc/transactional-update.conf_.

Notes:
- The configuration file is sourced after the definition of default variable values, so it is possible to redefine those. This may be a useful (undocumented) side effect, but it may also be worth to consider doing the import earlier to allow only a fixed set of variables (i.e. those mentioned in the man page).
- While it would be trivial to implement there's no mechanism for overriding default files (e.g. _/usr/etc/transactional-update.conf_) added yet. Instead the configuration options are listed in a separate manual page **transactional-update.conf(5)**.