### PR TITLE
Use awk on /proc/mounts instead of grep on fstab

### DIFF
--- a/sbin/transactional-update.in
+++ b/sbin/transactional-update.in
@@ -619,7 +619,7 @@ if [ -n "${ZYPPER_ARG}" -o ${REWRITE_GRUB_CFG} -eq 1 \
 
     # Check which directories in /boot/grub2 need to be mounted,
     # otherwise grub2 will not boot after a version update.
-    DIR_TO_MOUNT="${DIR_TO_MOUNT} `grep /boot/grub2/ /etc/fstab |grep subvol | awk '{print $2}'`"
+    DIR_TO_MOUNT="${DIR_TO_MOUNT} $(awk '$2 ~ /\/boot\/grub2\// { print $2 }' /proc/mounts)"
 
 
     # Mount everything we need:


### PR DESCRIPTION
- Use awk instead of grep | grep | awk
- Only match the path and not the entire line to avoid matching comments

I got the same output for both commands on a test system.